### PR TITLE
Compatibility with dev dbplyr

### DIFF
--- a/R/DataBackendDplyr.R
+++ b/R/DataBackendDplyr.R
@@ -273,11 +273,7 @@ DataBackendDplyr = R6Class("DataBackendDplyr", inherit = DataBackend, cloneable 
   private = list(
     .calculate_hash = function() {
       private$.reconnect()
-      if (inherits(private$.data, "tbl_lazy")) {
-        calculate_hash(private$.data$ops, private$.data$con)
-      } else {
-        calculate_hash(private$.data)
-      }
+      calculate_hash(private$.data)
     },
 
     .reconnect = function() {


### PR DESCRIPTION
The lazy table fields used to calculate the hash don't exist anymore, so the hash calculation is wrong with the currently released dbplyr version.
The dev version of dbplyr now produces an error when accessing these fields.
It would be great if you could merge this and release to CRAN soon, so that we can release dbplyr.